### PR TITLE
Re-enable Renovate

### DIFF
--- a/.github/README-renovate.md
+++ b/.github/README-renovate.md
@@ -1,4 +1,4 @@
-# No dependabot.yml?
+# No Gradle Dependency Updates
 
 This repository contains **Java POJO classes for IATA ONE Record** (1R), as per
 official IATA Ontology on GitHub at https://github.com/IATA-Cargo/ONE-Record.
@@ -8,4 +8,4 @@ To ensure compatibility with
 the libraries used will not be used with their latest version but with the version which are used
 in that project. 
 
-This is the reason why this project does not and should not apply github's dependabot.yml feature.
+This is the reason why the "gradle" manager for Renovate has been disabled.

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,9 @@
-NOT ACTIVE, SEE README-dependabot.xml for reason
-
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
-  ]
+  ],
+  "gradle": {
+    "enabled": false
+  }
 }


### PR DESCRIPTION
I understand that you don't want Renovate to upgrade your Java dependencies automatically. IMHO you should still enable Renovate even for the Java dependencies but disable automerge completely. New releases of the library will then have dependency version bumps in their release notes.

In the meantime let's enable Renovate at least for everything else but Java/Gradle dependencies. This is what this PR does.